### PR TITLE
feat: support email contact and parse files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/node_models
-packge-lock.json
-.vscode
+node_modules/
+dist/
+package-lock.json
+.vscode/

--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
     "jest": "^26.0.0",
     "ts-jest": "^26.5.6",
     "typescript": "^4.0.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
   }
 }

--- a/src/parser/buiParser.ts
+++ b/src/parser/buiParser.ts
@@ -1,35 +1,22 @@
-import { createToken, Lexer, CstParser } from 'chevrotain';
 import { ParsedAST } from '../types';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-const WhiteSpace = createToken({ name: 'WhiteSpace', pattern: /[ \t\r\n]+/, group: Lexer.SKIPPED });
-const Profile = createToken({ name: 'Profile', pattern: /profile:/ });
-const BPod = createToken({ name: 'BPod', pattern: /b-pod/ });
-const LCurly = createToken({ name: 'LCurly', pattern: /\{/ });
-const RCurly = createToken({ name: 'RCurly', pattern: /\}/ });
-const StringLiteral = createToken({ name: 'StringLiteral', pattern: /"[^"]*"/ });
-const Colon = createToken({ name: 'Colon', pattern: /:/ });
-const Comma = createToken({ name: 'Comma', pattern: /,/ });
-const DashSep = createToken({ name: 'DashSep', pattern: /---/ });
-const Identifier = createToken({ name: 'Identifier', pattern: /[a-zA-Z_][a-zA-Z0-9_-]*/ });
-const LBracket = createToken({ name: 'LBracket', pattern: /\[/ });
-const RBracket = createToken({ name: 'RBracket', pattern: /\]/ });
-const LParen = createToken({ name: 'LParen', pattern: /\(/ });
-const RParen = createToken({ name: 'RParen', pattern: /\)/ });
-const NumberLiteral = createToken({ name: 'NumberLiteral', pattern: /[0-9]+/ });
-const Any = createToken({ name: 'Any', pattern: /[^\s]+/ });
+function parseObjectBlock(block: string): any {
+    // Parse a JS-like object block (unquoted keys etc.) by evaluating it in a
+    // new function scope. The block is wrapped in parentheses to allow object
+    // literals at the top level.
+    try {
+        // eslint-disable-next-line no-new-func
+        return Function(`"use strict"; return (${block});`)();
+    } catch (e) {
+        throw new Error('Invalid block');
+    }
+}
 
-export const allTokens = [
-    WhiteSpace, Profile, BPod, LCurly, RCurly, StringLiteral, Colon, Comma, DashSep,
-    Identifier, LBracket, RBracket, LParen, RParen, NumberLiteral, Any
-];
-
-export const BuiLexer = new Lexer(allTokens);
-
-export function parseBuiFile(buiContent: string): ParsedAST {
-    // Minimal Chevrotain-based split for profile and bPods (for demo, not full grammar)
-    // TODO: Replace with full Chevrotain CST/AST parser for .bui v1.0.0
+export async function parseBuiFile(filePath: string): Promise<ParsedAST> {
+    const buiContent = await fs.readFile(filePath, 'utf-8');
+    // Minimal split for profile and bPods (for demo, not full grammar)
     const sections = buiContent.split(/\n---+\n/);
     if (!sections[0].trim().startsWith('profile:')) {
         throw new Error('profile section must be first');
@@ -37,11 +24,11 @@ export function parseBuiFile(buiContent: string): ParsedAST {
 
     const profileMatch = sections[0].match(/profile:\s*({[\s\S]*})/);
     if (!profileMatch) throw new Error('Invalid profile block');
-    const profile = JSON.parse(profileMatch[1]);
+    const profile = parseObjectBlock(profileMatch[1]);
     const bPods = sections.slice(1).map(section => {
-        const nameMatch = section.match(/b-pod\s+"([^"]+)"\s*{([\s\S]*)}/);
+        const nameMatch = section.match(/b-pod\s+"([^"]+)"\s*({[\s\S]*})/);
         if (!nameMatch) throw new Error('Invalid b-pod block');
-        return { name: nameMatch[1], ...JSON.parse('{' + nameMatch[2] + '}') };
+        return { name: nameMatch[1], ...parseObjectBlock(nameMatch[2]) };
     });
     return { profile, bPods };
 }
@@ -51,15 +38,15 @@ export async function parseBuiFolder(folderPath: string): Promise<ParsedAST> {
     const profileContent = await fs.readFile(indexPath, 'utf-8');
     const profileMatch = profileContent.match(/profile:\s*({[\s\S]*})/);
     if (!profileMatch) throw new Error('Invalid profile block in index.bui');
-    const profile = JSON.parse(profileMatch[1]);
+    const profile = parseObjectBlock(profileMatch[1]);
     const files = await fs.readdir(folderPath);
     const bPodFiles = files.filter(f => f.endsWith('.bui') && f !== 'index.bui');
     const bPods = [];
     for (const file of bPodFiles) {
         const content = await fs.readFile(path.join(folderPath, file), 'utf-8');
-        const nameMatch = content.match(/b-pod\s+"([^"]+)"\s*{([\s\S]*)}/);
+        const nameMatch = content.match(/b-pod\s+"([^"]+)"\s*({[\s\S]*})/);
         if (!nameMatch) throw new Error(`Invalid b-pod block in ${file}`);
-        bPods.push({ name: nameMatch[1], ...JSON.parse('{' + nameMatch[2] + '}') });
+        bPods.push({ name: nameMatch[1], ...parseObjectBlock(nameMatch[2]) });
     }
     return { profile, bPods };
 }

--- a/src/parser/buiParser.ts
+++ b/src/parser/buiParser.ts
@@ -1,52 +1,258 @@
 import { ParsedAST } from '../types';
-import * as fs from 'fs/promises';
-import * as path from 'path';
 
-function parseObjectBlock(block: string): any {
-    // Parse a JS-like object block (unquoted keys etc.) by evaluating it in a
-    // new function scope. The block is wrapped in parentheses to allow object
-    // literals at the top level.
-    try {
-        // eslint-disable-next-line no-new-func
-        return Function(`"use strict"; return (${block});`)();
-    } catch (e) {
-        throw new Error('Invalid block');
+let initialized = false;
+let createToken: any, Lexer: any, CstParser: any, IToken: any;
+let WhiteSpace: any, Profile: any, BPod: any, Dashes: any, LCurly: any, RCurly: any,
+  LSquare: any, RSquare: any, Colon: any, Comma: any, StringLiteral: any,
+  NumberLiteral: any, True: any, False: any, NullTok: any, Identifier: any;
+let allTokens: any[], BuiLexer: any, parser: any, astBuilder: any;
+
+async function init() {
+  if (initialized) return;
+  // @ts-ignore - Chevrotain ESM module without types for direct path
+  const chev: any = await import('chevrotain/lib/chevrotain.mjs');
+  ({ createToken, Lexer, CstParser, IToken } = chev);
+
+  WhiteSpace = createToken({ name: 'WhiteSpace', pattern: /\s+/, group: Lexer.SKIPPED });
+  Profile = createToken({ name: 'Profile', pattern: /profile/ });
+  BPod = createToken({ name: 'BPod', pattern: /b-pod/ });
+  Dashes = createToken({ name: 'Dashes', pattern: /---/ });
+  LCurly = createToken({ name: 'LCurly', pattern: /\{/ });
+  RCurly = createToken({ name: 'RCurly', pattern: /\}/ });
+  LSquare = createToken({ name: 'LSquare', pattern: /\[/ });
+  RSquare = createToken({ name: 'RSquare', pattern: /\]/ });
+  Colon = createToken({ name: 'Colon', pattern: /:/ });
+  Comma = createToken({ name: 'Comma', pattern: /,/ });
+  StringLiteral = createToken({ name: 'StringLiteral', pattern: /"([^"\\]|\\.)*"/ });
+  NumberLiteral = createToken({ name: 'NumberLiteral', pattern: /-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/ });
+  True = createToken({ name: 'True', pattern: /true/ });
+  False = createToken({ name: 'False', pattern: /false/ });
+  NullTok = createToken({ name: 'Null', pattern: /null/ });
+  Identifier = createToken({ name: 'Identifier', pattern: /[a-zA-Z_][a-zA-Z0-9_]*/ });
+
+  allTokens = [
+    WhiteSpace,
+    Profile,
+    BPod,
+    True,
+    False,
+    NullTok,
+    StringLiteral,
+    NumberLiteral,
+    LCurly,
+    RCurly,
+    LSquare,
+    RSquare,
+    Comma,
+    Colon,
+    Dashes,
+    Identifier,
+  ];
+
+  BuiLexer = new Lexer(allTokens);
+
+  class BuiParser extends CstParser {
+    constructor() {
+      super(allTokens, { maxLookahead: 2 });
+      this.performSelfAnalysis();
     }
-}
 
-export async function parseBuiFile(filePath: string): Promise<ParsedAST> {
-    const buiContent = await fs.readFile(filePath, 'utf-8');
-    // Minimal split for profile and bPods (for demo, not full grammar)
-    const sections = buiContent.split(/\n---+\n/);
-    if (!sections[0].trim().startsWith('profile:')) {
-        throw new Error('profile section must be first');
-    }
-
-    const profileMatch = sections[0].match(/profile:\s*({[\s\S]*})/);
-    if (!profileMatch) throw new Error('Invalid profile block');
-    const profile = parseObjectBlock(profileMatch[1]);
-    const bPods = sections.slice(1).map(section => {
-        const nameMatch = section.match(/b-pod\s+"([^"]+)"\s*({[\s\S]*})/);
-        if (!nameMatch) throw new Error('Invalid b-pod block');
-        return { name: nameMatch[1], ...parseObjectBlock(nameMatch[2]) };
+    public file = this.RULE('file', () => {
+      this.SUBRULE(this.profileSection);
+      this.MANY(() => {
+        this.CONSUME(Dashes);
+        this.SUBRULE(this.bpodSection);
+      });
     });
-    return { profile, bPods };
+
+    public profileOnly = this.RULE('profileOnly', () => {
+      this.SUBRULE(this.profileSection);
+    });
+
+    public bpodOnly = this.RULE('bpodOnly', () => {
+      this.SUBRULE(this.bpodSection);
+    });
+
+    private profileSection = this.RULE('profileSection', () => {
+      this.CONSUME(Profile);
+      this.CONSUME(Colon);
+      this.SUBRULE(this.object);
+    });
+
+    private bpodSection = this.RULE('bpodSection', () => {
+      this.CONSUME(BPod);
+      this.CONSUME(StringLiteral);
+      this.SUBRULE(this.object);
+    });
+
+    private object = this.RULE('object', () => {
+      this.CONSUME(LCurly);
+      this.OPTION(() => {
+        this.SUBRULE(this.property);
+        this.MANY(() => {
+          this.CONSUME(Comma);
+          this.SUBRULE2(this.property);
+        });
+      });
+      this.CONSUME(RCurly);
+    });
+
+    private property = this.RULE('property', () => {
+      this.OR([
+        { ALT: () => this.CONSUME(StringLiteral) },
+        { ALT: () => this.CONSUME(Identifier) },
+      ]);
+      this.CONSUME(Colon);
+      this.SUBRULE(this.value);
+    });
+
+    private array = this.RULE('array', () => {
+      this.CONSUME(LSquare);
+      this.OPTION(() => {
+        this.SUBRULE(this.value);
+        this.MANY(() => {
+          this.CONSUME(Comma);
+          this.SUBRULE2(this.value);
+        });
+      });
+      this.CONSUME(RSquare);
+    });
+
+    private value = this.RULE('value', () => {
+      this.OR([
+        { ALT: () => this.CONSUME(StringLiteral) },
+        { ALT: () => this.CONSUME(NumberLiteral) },
+        { ALT: () => this.SUBRULE(this.object) },
+        { ALT: () => this.SUBRULE(this.array) },
+        { ALT: () => this.CONSUME(True) },
+        { ALT: () => this.CONSUME(False) },
+        { ALT: () => this.CONSUME(NullTok) },
+      ]);
+    });
+  }
+
+  parser = new BuiParser();
+  const BaseVisitor = parser.getBaseCstVisitorConstructor();
+
+  class AstBuilder extends BaseVisitor {
+    constructor() {
+      super();
+      this.validateVisitor();
+    }
+
+    file(ctx: any): ParsedAST {
+      const profile = this.visit(ctx.profileSection[0]);
+      const bPods = (ctx.bpodSection || []).map((b: any) => this.visit(b));
+      return { profile, bPods };
+    }
+
+    profileOnly(ctx: any): any {
+      return this.visit(ctx.profileSection[0]);
+    }
+
+    bpodOnly(ctx: any): any {
+      return this.visit(ctx.bpodSection[0]);
+    }
+
+    profileSection(ctx: any): any {
+      return this.visit(ctx.object[0]);
+    }
+
+    bpodSection(ctx: any): any {
+      const nameTok: typeof IToken = ctx.StringLiteral[0];
+      const obj = this.visit(ctx.object[0]);
+      return { name: stripQuotes(nameTok.image), ...obj };
+    }
+
+    object(ctx: any): any {
+      const obj: any = {};
+      if (ctx.property) {
+        ctx.property.forEach((p: any) => {
+          const { key, value } = this.visit(p);
+          obj[key] = value;
+        });
+      }
+      return obj;
+    }
+
+    property(ctx: any): any {
+      const keyTok: typeof IToken = ctx.StringLiteral ? ctx.StringLiteral[0] : ctx.Identifier[0];
+      const key = stripQuotes(keyTok.image);
+      const value = this.visit(ctx.value[0]);
+      return { key, value };
+    }
+
+    array(ctx: any): any[] {
+      const arr: any[] = [];
+      if (ctx.value) {
+        ctx.value.forEach((v: any) => arr.push(this.visit(v)));
+      }
+      return arr;
+    }
+
+    value(ctx: any): any {
+      if (ctx.StringLiteral) return stripQuotes(ctx.StringLiteral[0].image);
+      if (ctx.NumberLiteral) return Number(ctx.NumberLiteral[0].image);
+      if (ctx.object) return this.visit(ctx.object[0]);
+      if (ctx.array) return this.visit(ctx.array[0]);
+      if (ctx.True) return true;
+      if (ctx.False) return false;
+      return null; // Null token
+    }
+  }
+
+  astBuilder = new AstBuilder();
+  initialized = true;
 }
 
-export async function parseBuiFolder(folderPath: string): Promise<ParsedAST> {
-    const indexPath = path.join(folderPath, 'index.bui');
-    const profileContent = await fs.readFile(indexPath, 'utf-8');
-    const profileMatch = profileContent.match(/profile:\s*({[\s\S]*})/);
-    if (!profileMatch) throw new Error('Invalid profile block in index.bui');
-    const profile = parseObjectBlock(profileMatch[1]);
-    const files = await fs.readdir(folderPath);
-    const bPodFiles = files.filter(f => f.endsWith('.bui') && f !== 'index.bui');
-    const bPods = [];
-    for (const file of bPodFiles) {
-        const content = await fs.readFile(path.join(folderPath, file), 'utf-8');
-        const nameMatch = content.match(/b-pod\s+"([^"]+)"\s*({[\s\S]*})/);
-        if (!nameMatch) throw new Error(`Invalid b-pod block in ${file}`);
-        bPods.push({ name: nameMatch[1], ...parseObjectBlock(nameMatch[2]) });
-    }
-    return { profile, bPods };
+function stripQuotes(str: string): string {
+  return str.replace(/^"|"$/g, '');
 }
+
+export async function parseSingleContent(content: string): Promise<ParsedAST> {
+  await init();
+  const lex = BuiLexer.tokenize(content);
+  if (lex.errors.length) {
+    throw new Error('Lexing errors detected');
+  }
+  parser.input = lex.tokens;
+  const cst = parser.file();
+  if (parser.errors.length) {
+    throw new Error('Parsing errors detected');
+  }
+  return astBuilder.file(cst);
+}
+
+export async function parseProfileContent(content: string): Promise<any> {
+  await init();
+  const lex = BuiLexer.tokenize(content);
+  if (lex.errors.length) throw new Error('Lexing errors detected');
+  parser.input = lex.tokens;
+  const cst = parser.profileOnly();
+  if (parser.errors.length) throw new Error('Parsing errors detected');
+  return astBuilder.profileOnly(cst);
+}
+
+export async function parseBpodContent(content: string): Promise<any> {
+  await init();
+  const lex = BuiLexer.tokenize(content);
+  if (lex.errors.length) throw new Error('Lexing errors detected');
+  parser.input = lex.tokens;
+  const cst = parser.bpodOnly();
+  if (parser.errors.length) throw new Error('Parsing errors detected');
+  return astBuilder.bpodOnly(cst);
+}
+
+export async function parseFromFiles(files: Record<string, string>): Promise<ParsedAST> {
+  if (files['index.bui']) {
+    const profile = await parseProfileContent(files['index.bui']);
+    const bPodsPromises = Object.entries(files)
+      .filter(([name]) => name !== 'index.bui' && name.endsWith('.bui'))
+      .map(([, content]) => parseBpodContent(content));
+    const bPods = await Promise.all(bPodsPromises);
+    return { profile, bPods };
+  }
+  const firstKey = Object.keys(files)[0];
+  return parseSingleContent(files[firstKey]);
+}
+

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,0 +1,14 @@
+import { ParsedAST } from './types';
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+export function renderAstToHtml(ast: ParsedAST): string {
+  const profile = ast.profile;
+  const profileHtml = `<section class="profile"><h1>${escapeHtml(profile.name)}</h1><p>${escapeHtml(profile.description || '')}</p></section>`;
+  const bPodsHtml = ast.bPods
+    .map(bp => `<section class="bpod"><h2>${escapeHtml(bp.name)}</h2></section>`)
+    .join('\n');
+  return `${profileHtml}\n${bPodsHtml}`;
+}

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -10,3 +10,8 @@ export function isValidURL(url: string): boolean {
 export function isNonEmptyArray(arr: any): boolean {
   return Array.isArray(arr) && arr.length > 0;
 }
+
+export function isValidEmail(email: string): boolean {
+  const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return re.test(email);
+}

--- a/src/validator/validateAST.ts
+++ b/src/validator/validateAST.ts
@@ -1,5 +1,5 @@
 import { ParsedAST, ValidationError, BPod, BPodInput } from '../types';
-import { isValidURL, isNonEmptyArray } from '../utils';
+import { isValidURL, isNonEmptyArray, isValidEmail } from '../utils';
 
 export function validateAST(ast: ParsedAST): ValidationError[] {
     const errors: ValidationError[] = [];
@@ -32,8 +32,8 @@ export function validateAST(ast: ParsedAST): ValidationError[] {
         errors.push({ message: 'Invalid website URL in profile', line: 1, column: 1, severity: 'warning' });
     }
 
-    if (profile.contact && !isValidURL(profile.contact)) {
-        errors.push({ message: 'Invalid contact URL in profile', line: 1, column: 1, severity: 'warning' });
+    if (profile.contact && !(isValidURL(profile.contact) || isValidEmail(profile.contact))) {
+        errors.push({ message: 'Invalid contact in profile', line: 1, column: 1, severity: 'warning' });
     }
 
     // Validate bPods

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -1,20 +1,34 @@
-import { compileBui } from '../src';
+import { compile, render } from '../src';
 import * as path from 'path';
+import { promises as fs } from 'fs';
 
 describe('Breeth BUI Compiler', () => {
   it('parses single-file example without errors', async () => {
     const filePath = path.join(__dirname, '..', 'example', 'example.bui');
-    const result = await compileBui(filePath, 'single');
+    const content = await fs.readFile(filePath, 'utf-8');
+    const result = await compile({ 'example.bui': content });
     expect(result.errors).toHaveLength(0);
-    expect(result.parsed?.profile.name).toBe('SoundAI Labs');
-    expect(result.parsed?.bPods.length).toBe(1);
+    expect(result.ast.profile.name).toBe('SoundAI Labs');
+    expect(result.ast.bPods.length).toBe(1);
   });
 
   it('parses folder example without errors', async () => {
     const folderPath = path.join(__dirname, '..', 'example', 'soundai-folder');
-    const result = await compileBui(folderPath, 'folder');
+    const files = await fs.readdir(folderPath);
+    const map: Record<string, string> = {};
+    for (const f of files) {
+      map[f] = await fs.readFile(path.join(folderPath, f), 'utf-8');
+    }
+    const result = await compile(map);
     expect(result.errors).toHaveLength(0);
-    expect(result.parsed?.bPods.length).toBe(2);
-    expect(result.parsed?.profile.contact).toBe('support@soundai.com');
+    expect(result.ast.bPods.length).toBe(2);
+    expect(result.ast.profile.contact).toBe('support@soundai.com');
+  });
+
+  it('renders html output', async () => {
+    const filePath = path.join(__dirname, '..', 'example', 'example.bui');
+    const content = await fs.readFile(filePath, 'utf-8');
+    const html = await render({ 'example.bui': content });
+    expect(html).toContain('<h1>SoundAI Labs</h1>');
   });
 });

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -1,0 +1,20 @@
+import { compileBui } from '../src';
+import * as path from 'path';
+
+describe('Breeth BUI Compiler', () => {
+  it('parses single-file example without errors', async () => {
+    const filePath = path.join(__dirname, '..', 'example', 'example.bui');
+    const result = await compileBui(filePath, 'single');
+    expect(result.errors).toHaveLength(0);
+    expect(result.parsed?.profile.name).toBe('SoundAI Labs');
+    expect(result.parsed?.bPods.length).toBe(1);
+  });
+
+  it('parses folder example without errors', async () => {
+    const folderPath = path.join(__dirname, '..', 'example', 'soundai-folder');
+    const result = await compileBui(folderPath, 'folder');
+    expect(result.errors).toHaveLength(0);
+    expect(result.parsed?.bPods.length).toBe(2);
+    expect(result.parsed?.profile.contact).toBe('support@soundai.com');
+  });
+});


### PR DESCRIPTION
## Summary
- parse `.bui` files from disk, supporting folder and single-file modes
- accept email addresses in profile contact field
- add basic compiler tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68928cdee67c8327a9829bac88610b13